### PR TITLE
Make sure file resource will create an actual file

### DIFF
--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -68,8 +68,13 @@ define upstart::job (
 
   $config_path = "${upstart::init_dir}/${name}.conf"
 
+  if ($ensure == 'present') {
+    $file_ensure = 'file'
+  } else {
+    $file_ensure = 'absent'
+  }
   file { $config_path:
-    ensure  => $ensure,
+    ensure  => $file_ensure,
     owner   => 'root',
     group   => 'root',
     mode    => '0644',


### PR DESCRIPTION
There is a file ensure that can either be 'present' or 'absent' but really should be 'file' or 'absent'. Otherwise an older upstart job (installed before puppet ran) with the same name but being a symlink does not get replaced by the template.