### PR TITLE
Refresh of service (default: true) when upstart job file changes

### DIFF
--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -34,6 +34,7 @@ define upstart::job (
   $script              = undef,
   $exec                = undef,
   $restart             = undef,
+  $refresh             = true,
   $task                = false,
   $run_type_service    = true,
 ) {
@@ -91,11 +92,16 @@ define upstart::job (
       # but this works well enough for now.
       if $ensure == 'present' {
         service { $name:
-          ensure    => $service_ensure,
-          enable    => $service_enable,
-          provider  => 'upstart',
-          require   => File[$config_path],
-          subscribe => File[$config_path],
+          ensure   => $service_ensure,
+          enable   => $service_enable,
+          provider => 'upstart',
+          require  => File[$config_path],
+        }
+
+        if $refresh {
+          Service[$name] {
+            subscribe => File[$config_path],
+          }
         }
 
         if !empty($restart) {


### PR DESCRIPTION
I need to be able to update my upstart jobs without the jobs restarting when puppet runs. I need to plan the restarts at other times. I hope my pull request can be accepted and your module updated. 